### PR TITLE
Add dynamic routes to sitemap.xml

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,5 @@
+const fs = require('fs')
+const path = require('path')
 
 module.exports = {
   mode: 'universal',
@@ -38,6 +40,10 @@ module.exports = {
     '@nuxtjs/sitemap',
     '@nuxtjs/markdownit',
   ],
+  sitemap: {
+    routes: () =>
+      fs.readdirSync('md').map(file => path.parse(file).name)
+  },
   /*
   ** Build configuration
   */


### PR DESCRIPTION
Currently the dynamic routes from the wildcard page `_.vue` are missing from your `sitemap.xml`.

This patch reads your markdown directory and inject dynamically each associated route to the sitemap configuration 😉 